### PR TITLE
Changes to frontend

### DIFF
--- a/src/frontend/AlertSettings.fxml
+++ b/src/frontend/AlertSettings.fxml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.RadioButton?>
 <?import javafx.scene.control.TextArea?>
 <?import javafx.scene.layout.ColumnConstraints?>
@@ -10,7 +11,7 @@
 
 <Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="450.0" xmlns="http://javafx.com/javafx/9.0.4" xmlns:fx="http://javafx.com/fxml/1" fx:controller="frontend.AlertSettingsGridController">
     <children>
-        <TextArea prefHeight="200.0" prefWidth="450.0" text="Alerts&#10;Settings">
+        <TextArea editable="false" prefHeight="200.0" prefWidth="450.0" text="Alerts&#10;Settings">
             <font>
                 <Font size="54.0" />
             </font>
@@ -25,24 +26,24 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
-            <TextArea prefHeight="90.0" prefWidth="240.0" text="Alert">
+            <TextArea editable="false" prefHeight="90.0" prefWidth="240.0" text="Alert">
                <font>
                   <Font size="26.0" />
                </font>
             </TextArea>
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="Active" GridPane.columnIndex="1">
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="Active" GridPane.columnIndex="1">
                <font>
                   <Font size="26.0" />
                </font>
             </TextArea>
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="High&#10;Priority" GridPane.columnIndex="2">
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="High&#10;Priority" GridPane.columnIndex="2">
                <font>
                   <Font size="26.0" />
                </font>
             </TextArea>
          </children>
       </GridPane>
-      <GridPane layoutY="290.0" prefHeight="510.0" prefWidth="450.0">
+      <GridPane layoutY="290.0" prefHeight="470.0" prefWidth="450.0">
         <columnConstraints>
           <ColumnConstraints hgrow="SOMETIMES" maxWidth="202.0" minWidth="10.0" prefWidth="194.0" />
           <ColumnConstraints hgrow="SOMETIMES" maxWidth="192.0" minWidth="10.0" prefWidth="117.0" />
@@ -56,7 +57,7 @@
             <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="&#10;Heavy Rain">
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="&#10;Rain">
                <font>
                   <Font size="20.0" />
                </font>
@@ -71,22 +72,22 @@
                   <Font size="27.0" />
                </font>
             </RadioButton>
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="&#10;Heavy Rain" GridPane.rowIndex="1">
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="&#10;Sleet" GridPane.rowIndex="1">
                <font>
                   <Font size="20.0" />
                </font>
             </TextArea>
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="&#10;Heavy Rain" GridPane.rowIndex="2">
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="&#10;Snow" GridPane.rowIndex="2">
                <font>
                   <Font size="20.0" />
                </font>
             </TextArea>
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="&#10;Heavy Rain" GridPane.rowIndex="3">
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="&#10;Wind" GridPane.rowIndex="3">
                <font>
                   <Font size="20.0" />
                </font>
             </TextArea>
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="&#10;Heavy Rain" GridPane.rowIndex="4">
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="&#10;Fog" GridPane.rowIndex="4">
                <font>
                   <Font size="20.0" />
                </font>
@@ -133,5 +134,6 @@
             </RadioButton>
          </children>
       </GridPane>
+      <Button id="buttonBack" fx:id="buttonBack" layoutY="760.0" mnemonicParsing="false" onAction="#handleButtonBack" prefHeight="27.0" prefWidth="450.0" text="Back" />
     </children>
 </Pane>

--- a/src/frontend/AlertSettingsGridController.java
+++ b/src/frontend/AlertSettingsGridController.java
@@ -1,17 +1,29 @@
 package frontend;
 
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.RadioButton;
+
+import java.io.IOException;
 
 public class AlertSettingsGridController extends ControllerMaster{
 
     @FXML
-    protected RadioButton rbA1, rbA2, rbA3, rbA4, rbA5, rbp1, rbp2, rbp3, rbp4, rbp5;
+    private RadioButton rbA1, rbA2, rbA3, rbA4, rbA5, rbp1, rbp2, rbp3, rbp4, rbp5;
+
+    @FXML
+    private Button buttonBack;
+
+    private SceneResource sceneResource;
 
 
     @Override
     protected void init(SceneResource resource) {
+        // will need alerts info from persistent storage.
+        // for now, the back button sets up a default choice first,
+        //(everything alterable, nothing priority)
 
+        sceneResource = resource;
     }
 
     /**
@@ -72,6 +84,18 @@ public class AlertSettingsGridController extends ControllerMaster{
     @FXML
     private void rbp5Handler(){
 
+    }
+
+    @FXML
+    private void handleButtonBack() throws IOException{
+
+        if(sceneResource == null){
+            sceneResource = new SceneResource();
+        }
+
+
+
+        switchScenesPassData("MainPage.fxml", buttonBack, sceneResource);
     }
 
 }

--- a/src/frontend/AlertsContext.java
+++ b/src/frontend/AlertsContext.java
@@ -1,0 +1,18 @@
+package frontend;
+
+import backend.WeatherType;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+public class AlertsContext {
+
+    private HashMap<WeatherType, Boolean> altertable;
+    private HashMap<WeatherType, Boolean> priority;
+
+    public AlertsContext(HashMap<WeatherType, Boolean> altertable, HashMap<WeatherType, Boolean> priority){
+        this.altertable = altertable;
+        this.priority = priority;
+    }
+
+}

--- a/src/frontend/LanguageSettings.fxml
+++ b/src/frontend/LanguageSettings.fxml
@@ -12,12 +12,12 @@
 
 <Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="450.0" xmlns="http://javafx.com/javafx/9.0.4" xmlns:fx="http://javafx.com/fxml/1" fx:controller="frontend.LanguagesController">
     <children>
-        <TextArea prefHeight="200.0" prefWidth="450.0" text="Language">
+        <TextArea editable="false" prefHeight="200.0" prefWidth="450.0" text="Language">
             <font>
                 <Font size="54.0" />
             </font>
         </TextArea>
-        <TextArea layoutX="2.0" layoutY="200.0" prefHeight="47.0" prefWidth="450.0" text="Select the language you want:">
+        <TextArea editable="false" layoutX="2.0" layoutY="200.0" prefHeight="47.0" prefWidth="450.0" text="Select the language you want:">
          <font>
             <Font size="26.0" />
          </font>
@@ -33,9 +33,9 @@
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
         </rowConstraints>
          <children>
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="English" />
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="Spanish" GridPane.rowIndex="1" />
-            <TextArea prefHeight="200.0" prefWidth="200.0" text="Other" GridPane.rowIndex="2" />
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="English" />
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="Spanish" GridPane.rowIndex="1" />
+            <TextArea editable="false" prefHeight="200.0" prefWidth="200.0" text="Other" GridPane.rowIndex="2" />
             <RadioButton mnemonicParsing="false" selected="true" translateX="50.0" GridPane.columnIndex="1">
                <font>
                   <Font size="24.0" />

--- a/src/frontend/LocationSettings.fxml
+++ b/src/frontend/LocationSettings.fxml
@@ -8,19 +8,19 @@
 
 <Pane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="800.0" prefWidth="450.0" xmlns="http://javafx.com/javafx/9.0.4" xmlns:fx="http://javafx.com/fxml/1" fx:controller="frontend.LocationsController">
     <children>
-        <TextArea prefHeight="200.0" prefWidth="450.0" text="Location">
+        <TextArea editable="false" prefHeight="200.0" prefWidth="450.0" text="Location">
             <font>
                 <Font size="54.0" />
             </font>
         </TextArea>
-         <TextArea layoutY="200.0" prefHeight="47.0" prefWidth="450.0" text="Current location:">
+         <TextArea editable="false" layoutY="200.0" prefHeight="47.0" prefWidth="450.0" text="Current location:">
             <font>
                 <Font size="26.0" />
             </font>
         </TextArea>
       <TextField fx:id="textFieldLocation" layoutX="2.0" layoutY="393.0" prefHeight="27.0" prefWidth="445.0" promptText="location search" />
-      <TextArea fx:id="textAreaCurrentLocation" layoutX="-2.0" layoutY="276.0" prefHeight="27.0" prefWidth="450.0" text="--current location goes here --" />
-      <TextArea layoutY="317.0" prefHeight="47.0" prefWidth="450.0" text="Search for new location:">
+      <TextArea fx:id="textAreaCurrentLocation" editable="false" layoutX="-2.0" layoutY="276.0" prefHeight="27.0" prefWidth="450.0" text="--current location goes here --" />
+      <TextArea editable="false" layoutY="317.0" prefHeight="47.0" prefWidth="450.0" text="Search for new location:">
          <font>
             <Font size="26.0" />
          </font>

--- a/src/frontend/LocationsController.java
+++ b/src/frontend/LocationsController.java
@@ -28,7 +28,10 @@ public class LocationsController extends ControllerMaster{
 
     @Override
     protected void init(SceneResource resource) {
-        //Todo does anything need to be initialised here
+
+        textAreaCurrentLocation.setText("Current Location: " + resource.getLocation());
+
+
     }
 
     @FXML
@@ -42,7 +45,11 @@ public class LocationsController extends ControllerMaster{
 
         //setting up resource with location
         SceneResource resource = new SceneResource();
-        resource.setLocation("anywhere else");
+        if(textFieldLocation.getText()!="") {
+            resource.setLocation(textFieldLocation.getText());
+        } else {
+            resource.setLocation("Cambridge");
+        }
 
         //passing in resource with location
 

--- a/src/frontend/SceneResource.java
+++ b/src/frontend/SceneResource.java
@@ -8,6 +8,9 @@ public class SceneResource {
      */
 
     private String location;
+    private boolean tempScale;
+    private boolean speedScale;
+    private AlertsContext alerts;
 
 
     /**
@@ -22,5 +25,21 @@ public class SceneResource {
 
     protected void setLocation(String location) {
         this.location = location;
+    }
+
+    protected boolean isTempScale() {
+        return tempScale;
+    }
+
+    protected void setTempScale(boolean tempScale) {
+        this.tempScale = tempScale;
+    }
+
+    public boolean isSpeedScale() {
+        return speedScale;
+    }
+
+    public void setSpeedScale(boolean speedScale) {
+        this.speedScale = speedScale;
     }
 }

--- a/src/frontend/SettingsController.java
+++ b/src/frontend/SettingsController.java
@@ -27,18 +27,23 @@ public class SettingsController extends ControllerMaster{
     @FXML
     private TextArea textAreaLocationInfo, textAreaTemperatureInfo, textAreaWindspeedInfo, textAreaLanguageInfo;
 
-    // The string used to set the location of the object
+    // Settings fields information
+    private String userLocation;  // the location for the API
+    private boolean tempScale; // true is centigrade, false is fahrenheit
+    private boolean speedScale; // true is mph, false is kph
 
+    private static final String defaultLocation = "Cambridge";
 
     @Override
     protected void init(SceneResource resource) {
 
-        //TODO include a check to see if the location has been updated before referencing it
-        if (!resource.getLocation().equals(null)){
+        if (!(resource.getLocation() == null) && !resource.getLocation().equals("")){
             //System.out.println(resource.getLocation());
             //System.out.print(textAreaLocationInfo.getText());
-            textAreaLocationInfo.setText(resource.getLocation());
+            textAreaLocationInfo.setText("Current Location: " + resource.getLocation());
+            userLocation = resource.getLocation();
         }
+        else textAreaLocationInfo.setText("Current Location: "+ defaultLocation);
 
     }
 
@@ -47,33 +52,44 @@ public class SettingsController extends ControllerMaster{
      * Handling the buttons
      */
 
-    //Todo the back button needs to go back to the homescreen
 
-    public void handleButtonBack(){
-        /**
-         * Here we go back to the previous screen, however it is that we do this
-         */
-        //System.out.println("Back button pressed");
+    public void handleButtonBack() throws IOException{
+
+        //pass back to main page, need to pass in the location and temp and speed scales
+
+        SceneResource resource = new SceneResource();
+        if(!(userLocation == null))
+            resource.setLocation(userLocation);
+        else
+            resource.setLocation(defaultLocation);
+        resource.setSpeedScale(speedScale);
+        resource.setTempScale(tempScale);
+
+
+        System.out.println(resource.getLocation());
+        System.out.println(resource.isSpeedScale());
+        System.out.println(resource.isTempScale());
+
+        switchScenesPassData("MainPage.fxml", buttonBack, resource);
+
     }
-
-    //Todo the location change now needs to go to the API section
 
     public void handleButtonLocationChange() throws IOException{
-        /**
-         * Here we go to location screen
-         */
-        //System.out.println("Location change button pressed");
 
-        //initialises the location of the static location to cambridge for now
-        //should load from a file that stores the data
+        //Passes current location to the locations pane
+        SceneResource sceneResource = new SceneResource();
+        if(userLocation!= null){
+            sceneResource.setLocation(userLocation);
+        } else {
+            sceneResource.setLocation(defaultLocation);
+        }
 
 
-        switchScenes("LocationSettings.fxml", buttonLocationChange);
+        switchScenesPassData("LocationSettings.fxml", buttonLocationChange, sceneResource);
 
 
     }
 
-    //TODO we will not bother implementing language, but the interface is there none the less
 
     public void handleButtonLanguageChange() throws IOException{
         /**
@@ -88,7 +104,6 @@ public class SettingsController extends ControllerMaster{
      */
 
 
-    //TODO actually change the scale being used for the temperature in the API
     public void handleSliderTemperature(){
 
         //<0.5 represents centigrade, >0.5 represents fahrenheit
@@ -99,9 +114,11 @@ public class SettingsController extends ControllerMaster{
 
         if(value >= 0.5){
             textAreaTemperatureInfo.setText("Scale: Centigrade");
+            tempScale = true;
         }
         else {
             textAreaTemperatureInfo.setText("Scale: Fahrenheit");
+            tempScale = false;
         }
 
     }
@@ -116,9 +133,11 @@ public class SettingsController extends ControllerMaster{
 
         if(value >= 0.5){
             textAreaWindspeedInfo.setText("Scale: Mph");
+            speedScale = true;
         }
         else {
             textAreaWindspeedInfo.setText("Scale: Kph");
+            speedScale = false;
         }
     }
 


### PR DESCRIPTION
Settings now passes a location, mph scale and windspeed scale to the main page every time the user goes back from settings

locations pane passes location to settings pane
settings pane passes location to locations pane

when a location is not specified, it is set to "Cambridge"
as a default.

SceneResource has extra fields added to accomodate speed and temp scales and alerts context
There is a new class AlertsContext which will could be used to store information on alerts
(although would be much easier with persistent storage rather than constantly passing it around)

The Alerts fxml page has alters corresponding to some of the enum types in the WeatherType class

In FXML pages, location, languages and alerts panes' text areas non editable

changes made to:
settings controller
locations controller
alerts controller
locations fxml
alerts fxml
languages fxml
SceneResource

created Alerts Context